### PR TITLE
Fix a stack uninitialized variable bug

### DIFF
--- a/fuzzer/src/depot/file.rs
+++ b/fuzzer/src/depot/file.rs
@@ -4,8 +4,11 @@ use std::{
     path::{Path, PathBuf},
 };
 
-pub fn get_file_name(dir: &Path, id: usize) -> PathBuf {
-    let file_name = format!("id:{:06}", id);
+pub fn get_file_name(dir: &Path, id: usize, time: Option<u128>) -> PathBuf {
+    let file_name = match time {
+        Some(t) => format!("id:{:06},{}", id, t),
+        None => format!("id:{:06}", id)
+    };
     dir.join(file_name)
 }
 

--- a/tools/llvm-diff-parmesan/id-assigner-pass/src/IDAssigner.cpp
+++ b/tools/llvm-diff-parmesan/id-assigner-pass/src/IDAssigner.cpp
@@ -437,6 +437,9 @@ void IDAssigner::addCustomTargetsFromFile(const std::string Path, Module *M) {
             static const std::string Xlibs("/usr/");
             if (filename.empty() || line == 0 || !filename.compare(0, Xlibs.size(), Xlibs))
                 continue;
+            std::size_t found0 = filename.find_last_of("/\\");
+            if (found0 != std::string::npos)
+              filename = filename.substr(found0 + 1);
             for (auto &target : targets) {
                 std::size_t found = target.find_last_of("/\\");
                 if (found != std::string::npos)

--- a/tools/llvm-diff-parmesan/id-assigner-pass/src/IDAssigner.cpp
+++ b/tools/llvm-diff-parmesan/id-assigner-pass/src/IDAssigner.cpp
@@ -92,6 +92,7 @@ Constant *ParmeSanDummyCall;
 void IDAssigner::collectCallSiteDominators(Function *F) {
     for (auto &BB : *F) {
       CallSiteIdType PrevCallSiteId;
+      bool HasPrevCallSiteId = false;
       for (auto &I : BB) {
           if (StoreInst *SI = dyn_cast<StoreInst>(&I)) {
               Value *V = SI->getPointerOperand();
@@ -102,6 +103,7 @@ void IDAssigner::collectCallSiteDominators(Function *F) {
                     if (CV) {
                         if (ConstantInt *ConstInt = dyn_cast<ConstantInt>(CV)) {
                             PrevCallSiteId = ConstInt->getZExtValue();
+                            HasPrevCallSiteId = true;
                         }
                     }
                 }
@@ -130,7 +132,8 @@ void IDAssigner::collectCallSiteDominators(Function *F) {
                     }
 
                   }
-                  CallSiteDominatorsMap[PrevCallSiteId] = CSDominatorCmpIds; 
+                  if (HasPrevCallSiteId)
+                    CallSiteDominatorsMap[PrevCallSiteId] = CSDominatorCmpIds; 
                   
               }
           }


### PR DESCRIPTION
This bug can cause `"callsite_dominators"` to generate a key with wrong number, which will cause following error when running fuzzer.

> thread 'main' panicked at 'Could not read cfg targets file: Custom { kind: InvalidData, error: Error("invalid digit found in string", line: 5, column: 1) }', fuzzer/src/fuzz_main.rs:42:72
